### PR TITLE
Fix the wrong indents in yaml files for jsonargparse

### DIFF
--- a/parameters/experiment/lasot/offline.yaml
+++ b/parameters/experiment/lasot/offline.yaml
@@ -13,6 +13,6 @@ tracker:
     transformer_mask: True
     backbone:
       return_layers: ["layer3"]
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1

--- a/parameters/experiment/lasot/online.yaml
+++ b/parameters/experiment/lasot/online.yaml
@@ -20,9 +20,9 @@ tracker:
     transformer_mask: False
     backbone:
       return_layers: ['layer3']
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1
 
   dcf:
     layers: ['layer2', 'layer3']

--- a/parameters/experiment/nfs/offline.yaml
+++ b/parameters/experiment/nfs/offline.yaml
@@ -13,6 +13,6 @@ tracker:
     transformer_mask: True
     backbone:
       return_layers: ["layer3"]
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1

--- a/parameters/experiment/nfs/online.yaml
+++ b/parameters/experiment/nfs/online.yaml
@@ -16,9 +16,9 @@ tracker:
     transformer_mask: False
     backbone:
       return_layers: ['layer3']
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1
 
   dcf:
     layers: ['layer2']

--- a/parameters/experiment/otb/offline.yaml
+++ b/parameters/experiment/otb/offline.yaml
@@ -13,6 +13,6 @@ tracker:
     transformer_mask: True
     backbone:
       return_layers: ["layer3"]
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1

--- a/parameters/experiment/otb/online.yaml
+++ b/parameters/experiment/otb/online.yaml
@@ -14,9 +14,9 @@ tracker:
     transformer_mask: False
     backbone:
       return_layers: ['layer3']
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1
 
   dcf:
     layers: ['layer2', 'layer3']

--- a/parameters/experiment/trackingnet/offline.yaml
+++ b/parameters/experiment/trackingnet/offline.yaml
@@ -13,6 +13,6 @@ tracker:
     transformer_mask: False
     backbone:
       return_layers: ["layer3"]
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1

--- a/parameters/experiment/trackingnet/online.yaml
+++ b/parameters/experiment/trackingnet/online.yaml
@@ -13,9 +13,9 @@ tracker:
     transformer_mask: False
     backbone:
       return_layers: ['layer3']
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1
 
   dcf:
     layers: ['layer2', 'layer3']

--- a/parameters/experiment/uav/offline.yaml
+++ b/parameters/experiment/uav/offline.yaml
@@ -13,6 +13,6 @@ tracker:
     transformer_mask: True
     backbone:
       return_layers: ["layer3"]
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1

--- a/parameters/experiment/uav/online.yaml
+++ b/parameters/experiment/uav/online.yaml
@@ -16,9 +16,9 @@ tracker:
     transformer_mask: False
     backbone:
       return_layers: ['layer3']
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1
 
   dcf:
     layers: ['layer2', 'layer3']

--- a/parameters/experiment/vot2018/offline.yaml
+++ b/parameters/experiment/vot2018/offline.yaml
@@ -13,6 +13,6 @@ tracker:
     transformer_mask: True
     backbone:
       return_layers: ["layer3"]
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1

--- a/parameters/experiment/vot2018/online.yaml
+++ b/parameters/experiment/vot2018/online.yaml
@@ -13,9 +13,9 @@ tracker:
     transformer_mask: False
     backbone:
       return_layers: ['layer3']
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1
 
   dcf:
     layers: ['layer2', 'layer3']

--- a/parameters/experiment/vot2019/offline.yaml
+++ b/parameters/experiment/vot2019/offline.yaml
@@ -13,6 +13,6 @@ tracker:
     transformer_mask: True
     backbone:
       return_layers: ["layer3"]
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1

--- a/parameters/experiment/vot2019/online.yaml
+++ b/parameters/experiment/vot2019/online.yaml
@@ -13,9 +13,9 @@ tracker:
     transformer_mask: False
     backbone:
       return_layers: ['layer3']
-      transformer:
-        enc_layers: 1
-        dec_layers: 1
+    transformer:
+      enc_layers: 1
+      dec_layers: 1
 
   dcf:
     layers: ['layer2', 'layer3']


### PR DESCRIPTION
namespace of `transformer` should have the same indent level with `backbone`